### PR TITLE
Fix alignment issue with prev nav

### DIFF
--- a/src/main/public/css/custom-style.css
+++ b/src/main/public/css/custom-style.css
@@ -129,7 +129,7 @@ TAB CSS
     .nav-tabs li,
     .nav-tabs .tabs-nav li {
         font-size: 16px;
-        line-height: 1.25
+        line-height: 2.25
     }
 }
 


### PR DESCRIPTION
Fixes the issue where on the first page `prev` is not aligned with the other navigation links.