### PR TITLE
Fixed delete test!!

### DIFF
--- a/e2e/upload-and-annotate-delete-pdf.e2e-spec.ts
+++ b/e2e/upload-and-annotate-delete-pdf.e2e-spec.ts
@@ -92,32 +92,13 @@ describe('Upload and Annotate a PDF', () => {
           expect(viewerPage.getCurrentNoteText()).toEqual(pageOneNote);
         });
 
-        describe('when I delete the note, save and refresh', () => {
+        describe('when I delete the note', () => {
           beforeAll(() => {
-            viewerPage.clearCurrentNote().then(() => {
-              viewerPage.getSaveButton().click();
-            });
+            viewerPage.clearCurrentNote();
+            viewerPage.getSaveButton().click();
           });
 
-          beforeAll(() => {
-            return browser.wait(function () {
-              return viewerPage.getSaveButton().isEnabled().then(enabled => {
-                console.log(enabled);
-                return !enabled;
-              });
-            }).then(() => {
-              browser.refresh();
-            });
-          });
-
-          beforeAll(() => {
-            return browser.wait(function () {
-              return viewerPage.isAnnotationsLoaded();
-            });
-          });
-
-          // Not working at the moment for some reason.
-          xit('should have deleted the note', () => {
+          it('should have deleted the note', () => {
             expect(viewerPage.getCurrentNoteText()).toEqual('');
           });
         });

--- a/e2e/viewer.po.ts
+++ b/e2e/viewer.po.ts
@@ -1,4 +1,4 @@
-import { browser, by, element } from 'protractor';
+import {browser, by, element, protractor} from 'protractor';
 
 export class ViewerPage {
   navigateTo() {
@@ -39,7 +39,7 @@ export class ViewerPage {
   }
 
   getSaveButton() {
-    return element.all(by.css('#notesForm button')).get(0);
+    return element(by.css('button[data-hook="dm.viewer.save-note"'));
   }
 
   getCancelButton() {
@@ -47,7 +47,10 @@ export class ViewerPage {
   }
 
   clearCurrentNote() {
-    return element(by.css('#currentNote')).clear();
+    const field = element(by.css('#currentNote'));
+    field.sendKeys(protractor.Key.chord(protractor.Key.CONTROL, 'a'));
+    field.sendKeys(protractor.Key.BACK_SPACE);
+    field.clear();
   }
 
   viewSummary() {


### PR DESCRIPTION
I finally found out that `element.clear()` doesn't kick off the Angular digest cycle so it wasn't enabling the save button - https://github.com/angular/protractor/issues/301.

So we now just select all and hit back space. Hacky but it works.